### PR TITLE
Support Node.js 10

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1111,6 +1111,12 @@ Client.prototype.connect = function connect() {
     socket.once('error', bail);
     socket.once('end', bail);
     socket.once('timeout', bail);
+    socket.once('cleanupSetupListeners', () => {
+      socket.removeListener('error', bail)
+        .removeListener('close', bail)
+        .removeListener('end', bail)
+        .removeListener('timeout', bail);
+    });
 
     self._socket = socket;
     self._tracker = tracker;
@@ -1147,10 +1153,8 @@ Client.prototype.connect = function connect() {
 
   // Wire up "official" event handlers after successful connect/setup
   function postSetup() {
-    socket.removeAllListeners('error')
-      .removeAllListeners('close')
-      .removeAllListeners('end')
-      .removeAllListeners('timeout');
+    // cleanup the listeners we attached in setup phrase.
+    socket.emit('cleanupSetupListeners');
 
     // Work around lack of close event on tls.socket in node < 0.11
     ((socket.socket) ? socket.socket : socket).once('close',


### PR DESCRIPTION
We observed some weird behaviors with node-ldapjs when upgraded to Node.js 10 LTS in our project.

- unbind not work (already reported as https://github.com/joyent/node-ldapjs/issues/483)
 - ldapjs UT hangs with Node.js 10

This issue is caused by some internal change in Node.js. See https://github.com/nodejs/node/issues/24577.

In summary, in Node.js 10, the `close` event depends on an internal `end` listener. so when ldap client use `removeAllListeners(`end`) to do cleanup work, the close listener stops working.

Node.js guys suggests that we should use `removeListener` to explicitly remove the listener we want to remove instead of using `removeAllListeners`. 

This PR didn't touch all of the `removeAllListeners` in client.js, just fixed the one who breaks `close `event.

@jgeurts, @melloc, could you help to review this PR?